### PR TITLE
Nicer logger names

### DIFF
--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -1,7 +1,6 @@
 import unittest, shutil, os, socket
 import numpy as np
-from astropy.coordinates import SkyCoord
-from astropy import units as u
+import logging
 
 from timewise import WiseDataByVisit, WISEDataDESYCluster, ParentSampleBase
 from timewise.general import main_logger
@@ -9,7 +8,7 @@ from timewise.utils import get_mirong_sample
 
 
 main_logger.setLevel('DEBUG')
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 
 mirong_sample = get_mirong_sample()

--- a/timewise/big_parent_sample.py
+++ b/timewise/big_parent_sample.py
@@ -3,11 +3,11 @@ import os
 import pickle
 import threading
 import time
+import logging
 
-from timewise.general import main_logger
 from timewise.parent_sample_base import ParentSampleBase
 
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 
 class BigParentSampleBase(ParentSampleBase):

--- a/timewise/general.py
+++ b/timewise/general.py
@@ -7,7 +7,8 @@ logger_format = logging.Formatter('%(levelname)s:%(threadName)s %(name)s - %(asc
 stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(logger_format)
 main_logger.addHandler(stream_handler)
-logger = main_logger.getChild(__name__)
+
+logger = logging.getLogger(__name__)
 
 # Setting up data directory
 DATA_DIR_KEY = 'TIMEWISE_DATA'

--- a/timewise/parent_sample_base.py
+++ b/timewise/parent_sample_base.py
@@ -1,12 +1,13 @@
 import abc, os
 import pandas as pd
 import numpy as np
+import logging
 
 from timewise.general import main_logger, cache_dir, plots_dir
 from timewise.utils import plot_sdss_cutout
 
 
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 
 class ParentSampleBase(abc.ABC):

--- a/timewise/point_source_utils.py
+++ b/timewise/point_source_utils.py
@@ -1,13 +1,13 @@
+import logging
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from timewise.general import main_logger
 from timewise.parent_sample_base import ParentSampleBase
 from timewise.wise_data_by_visit import WiseDataByVisit
 from timewise.utils import plot_sdss_cutout
 
 
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 
 ###########################################################################################################

--- a/timewise/utils.py
+++ b/timewise/utils.py
@@ -1,13 +1,17 @@
-import requests, os, getpass, backoff
+import requests
+import os
+import getpass
+import logging
 import pandas as pd
 import matplotlib.pyplot as plt
 import pyvo as vo
 import backoff
 
-from timewise.general import main_logger, cache_dir, backoff_hndlr
+
+from timewise.general import cache_dir, backoff_hndlr
 
 
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 mirong_url = 'http://staff.ustc.edu.cn/~jnac/data_public/wisevar.txt'
 local_copy = os.path.join(cache_dir, 'mirong_sample.csv')
 

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -15,12 +15,13 @@ import numpy as np
 import pandas as pd
 import pyvo as vo
 import traceback as tb
+import logging
 
-from timewise.general import main_logger, DATA_DIR_KEY, data_dir, bigdata_dir, backoff_hndlr
+from timewise.general import DATA_DIR_KEY, data_dir, bigdata_dir, backoff_hndlr
 from timewise.wise_data_by_visit import WiseDataByVisit
 
 
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 
 class WISEDataDESYCluster(WiseDataByVisit):

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -14,7 +14,7 @@ from timewise.general import main_logger, cache_dir, plots_dir, output_dir, logg
 from timewise.utils import StableTAPService
 
 
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 
 class WISEDataBase(abc.ABC):

--- a/timewise/wise_data_by_visit.py
+++ b/timewise/wise_data_by_visit.py
@@ -1,12 +1,12 @@
 import tqdm
 import pandas as pd
 import numpy as np
+import logging
 
-from timewise.general import main_logger
 from timewise.wise_data_base import WISEDataBase
 from timewise.utils import get_excess_variance
 
-logger = main_logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 
 class WiseDataByVisit(WISEDataBase):


### PR DESCRIPTION
replace `logger = main_logger.getChild(__name__)` with `logger = logging.getLogger(__name__)`