### PR TITLE
Removing outliers in bins during binning

### DIFF
--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -35,12 +35,13 @@ class WISEDataDESYCluster(WiseDataByVisit):
     # finding the file that contains the setup function tde_catalogue
     BASHFILE = os.getenv('TIMEWISE_DESY_CLUSTER_BASHFILE', os.path.expanduser('~/.bashrc'))
 
-    def __init__(self, base_name, parent_sample_class, min_sep_arcsec, n_chunks):
+    def __init__(self, base_name, parent_sample_class, min_sep_arcsec, n_chunks, clean_outliers_when_binning=True):
 
         super().__init__(base_name=base_name,
                          parent_sample_class=parent_sample_class,
                          min_sep_arcsec=min_sep_arcsec,
-                         n_chunks=n_chunks)
+                         n_chunks=n_chunks,
+                         clean_outliers_when_binning=clean_outliers_when_binning)
 
         # set up cluster stuff
         self.job_id = None
@@ -642,12 +643,12 @@ class WISEDataDESYCluster(WiseDataByVisit):
     def _save_cluster_info(self):
         logger.debug(f"writing cluster info to {self.cluster_info_file}")
         with open(self.cluster_info_file, "wb") as f:
-            pickle.dump((self.cluster_jobID_map, self.clusterJob_chunk_map), f)
+            pickle.dump((self.cluster_jobID_map, self.clusterJob_chunk_map, self.clean_outliers_when_binning), f)
 
     def _load_cluster_info(self):
         logger.debug(f"loading cluster info from {self.cluster_info_file}")
         with open(self.cluster_info_file, "rb") as f:
-            self.cluster_jobID_map, self.clusterJob_chunk_map = pickle.load(f)
+            self.cluster_jobID_map, self.clusterJob_chunk_map, self.clean_outliers_when_binning = pickle.load(f)
 
     def clear_cluster_log_dir(self):
         """
@@ -890,6 +891,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
 
     @cache
     def get_red_chi2(self, chunk, lum_key, use_bigdata_dir):
+        # TODO: add doc
 
         logger.info(f"extracting info for chunk {chunk}")
         data_product = self._load_data_product(
@@ -936,6 +938,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
             nbins=100,
             upper_bound=4
     ):
+        # TODO: add doc
 
         if chunks is None:
             chunks = list(range(self.n_chunks))

--- a/timewise/wise_data_by_visit.py
+++ b/timewise/wise_data_by_visit.py
@@ -21,6 +21,11 @@ class WiseDataByVisit(WISEDataBase):
     Npoints_key = '_Npoints'
     zeropoint_key_ext = '_zeropoint'
 
+    def __init__(self, base_name, parent_sample_class, min_sep_arcsec, n_chunks, clean_outliers_when_binning=True):
+        # TODO: add doc
+        super().__init__(base_name, parent_sample_class, min_sep_arcsec, n_chunks)
+        self.clean_outliers_when_binning = clean_outliers_when_binning
+
     def bin_lightcurve(self, lightcurve):
         """
         Combine the data by visits of the satellite of one region in the sky.
@@ -28,6 +33,7 @@ class WiseDataByVisit(WISEDataBase):
         six months.
         The mean flux for one visit is calculated by the weighted mean of the data.
         The error on that mean is calculated by the root-mean-squared.
+        # TODO: add doc about clean when binning
 
         :param lightcurve: the unbnned lightcurve
         :type lightcurve: pandas.DataFrame
@@ -102,21 +108,51 @@ class WiseDataByVisit(WISEDataBase):
                         e = epoch[f"{b}{lum_ext}{self.error_key_ext}"]
                         ulims = epoch[f"{b}{lum_ext}{self.upper_limit_key}"]
                         ul = np.all(pd.isna(e))
+                        nans = f.isna()
 
                         if ul:
-                            mean = np.mean(f)
+                            f = f[~nans]
                             u_mes = 0
                         else:
-                            f = f[~ulims]
-                            e = e[~ulims]
-                            iw = 1 / e**2
-                            w = iw / sum(iw)
-                            mean = np.average(f, weights=w)
+                            f = f[~ulims & ~nans]
+                            e = e[~ulims & ~nans]
                             u_mes = np.sqrt(sum(e ** 2 / len(e)))
 
-                        u_rms = np.sqrt(sum((f - mean) ** 2) / len(f))
+                        if len(f) == 0:
+                            continue
+
+        # ---------------------   remove outliers in the bins   ---------------------- #
+
+                        # if we do not want to clean outliers just set the threshold to infinity
+                        outlier_thresh = np.inf if not self.clean_outliers_when_binning else 3
+
+                        # set up empty masks
+                        remaining_outlier_mask = np.array([False] * len(f))
+                        outlier_mask = np.copy(remaining_outlier_mask)
+
+                        # set up dummy values for number of remaining and total outliers
+                        N_remaining_outlier = 1
+                        N_outlier = 0
+
+                        # recalculate rms and median as long as no outliers left
+                        while N_remaining_outlier > 0:
+                            f = f[~remaining_outlier_mask]
+                            mean = np.median(f)
+                            rms = np.sqrt(sum((f - mean) ** 2) / len(f))
+
+                            remaining_outlier_mask = abs(mean - f) > outlier_thresh * rms
+                            outlier_mask = outlier_mask | remaining_outlier_mask
+                            N_remaining_outlier = sum(remaining_outlier_mask)
+                            N_outlier += N_remaining_outlier
+
+                        if N_outlier > 0:
+                            logger.debug(f"{b}{lum_ext}, MJD {ei}: removed {N_outlier}")
+                            r[f"{b}{lum_ext}_outlier_indices"] = [list(outlier_mask.index[outlier_mask])]
+
+        # ---------------------   assemble final result   ---------------------- #
+
                         r[f'{b}{self.mean_key}{lum_ext}'] = mean
-                        r[f'{b}{lum_ext}{self.rms_key}'] = max(u_rms, u_mes)
+                        r[f'{b}{lum_ext}{self.rms_key}'] = max(rms, u_mes)
                         r[f'{b}{lum_ext}{self.upper_limit_key}'] = bool(ul)
                         r[f'{b}{lum_ext}{self.Npoints_key}'] = len(f)
                     except KeyError:

--- a/timewise/wise_data_by_visit.py
+++ b/timewise/wise_data_by_visit.py
@@ -112,11 +112,9 @@ class WiseDataByVisit(WISEDataBase):
 
                         if ul:
                             f = f[~nans]
-                            u_mes = 0
                         else:
                             f = f[~ulims & ~nans]
                             e = e[~ulims & ~nans]
-                            u_mes = np.sqrt(sum(e ** 2 / len(e)))
 
                         if len(f) == 0:
                             continue
@@ -148,6 +146,8 @@ class WiseDataByVisit(WISEDataBase):
                         if N_outlier > 0:
                             logger.debug(f"{b}{lum_ext}, MJD {ei}: removed {N_outlier}")
                             r[f"{b}{lum_ext}_outlier_indices"] = [list(outlier_mask.index[outlier_mask])]
+
+                        u_mes = 0 if ul else np.sqrt(sum(e[~outlier_mask] ** 2 / len(e[~outlier_mask])))
 
         # ---------------------   assemble final result   ---------------------- #
 


### PR DESCRIPTION
Sometimes single exposure datapoints are far away from the median in the bin. This would come from cosmic rays, wrongly associated detections or similar. They are definitely not wanted in the data and we can clean them. 