### PR TITLE
T distribution correction of error bars for bins with few datapoints

### DIFF
--- a/timewise/wise_data_by_visit.py
+++ b/timewise/wise_data_by_visit.py
@@ -47,8 +47,9 @@ class WiseDataByVisit(WISEDataBase):
         The visits typically consist of some tens of observations. The individual visits are separated by about
         six months.
         The mean flux for one visit is calculated by the weighted mean of the data.
-        The error on that mean is calculated by the root-mean-squared.
-        # TODO: add doc about clean when binning and error factor
+        The error on that mean is calculated by the root-mean-squared and corrected by the t-value.
+        Outliers per visit are identified if they are more than 100 times the rms away from the mean. These outliers
+        are removed from the calculation of the mean and the error if self.clean_outliers_when_binning is True.
 
         :param lightcurve: the unbinned lightcurve
         :type lightcurve: pandas.DataFrame


### PR DESCRIPTION
`WiseDataByVisit` now adds a factor of `stats.t.interval(0.68, df=len(f) - 1)[1]` to the errors. This is a correction taking into account the wider spread of the mean for a small number of datapoints.