### PR TITLE
Faster binning 

### DIFF
--- a/timewise/wise_data_by_visit.py
+++ b/timewise/wise_data_by_visit.py
@@ -40,7 +40,7 @@ class WiseDataByVisit(WISEDataBase):
         self.clean_outliers_when_binning = clean_outliers_when_binning
         self.multiply_flux_error = multiply_flux_error
 
-    def calculate_epoch(self, f, e, visit_mask, counts, remove_outliers):
+    def calculate_epoch(self, f, e, visit_mask, counts, remove_outliers, outlier_mask=None):
         # TODO: add doc
         u_lims = pd.isna(e)
 
@@ -50,7 +50,7 @@ class WiseDataByVisit(WISEDataBase):
         outlier_thresh = np.inf if not self.clean_outliers_when_binning else 100
 
         # set up empty masks
-        outlier_mask = np.array([False] * len(f))
+        outlier_mask = np.array([False] * len(f)) if outlier_mask is None else outlier_mask
         mean = np.nan
         u = np.nan
         use_mask = None
@@ -190,8 +190,8 @@ class WiseDataByVisit(WISEDataBase):
             # bin flux densities
             mean_fd, u_fd, ul_fd, outlier_mask_fd, use_mask_fd = self.calculate_epoch(
                 flux_densities, flux_densities_e, visit_mask, counts,
-                remove_outliers=False  # we do not remove outliers here because they have already been removed in
-                                       # the inst flux calculation
+                remove_outliers=False, outlier_mask=outlier_masks[self.flux_key_ext]
+                # we do not remove outliers here because they have already been removed in the inst flux calculation
             )
             n_points_fd = np.bincount(visit_mask, weights=use_mask)
             binned_data[f'{b}{self.mean_key}{self.flux_density_key_ext}'] = mean_fd

--- a/timewise/wise_data_by_visit.py
+++ b/timewise/wise_data_by_visit.py
@@ -41,6 +41,24 @@ class WiseDataByVisit(WISEDataBase):
         self.multiply_flux_error = multiply_flux_error
 
     def calculate_epoch(self, f, e, visit_mask, counts, remove_outliers, outlier_mask=None):
+        """
+        Calculates the epoch of a lightcurve.
+
+        :param f: the fluxes
+        :type f: np.array
+        :param e: the flux errors
+        :type e: np.array
+        :param visit_mask: the visit mask
+        :type visit_mask: np.array
+        :param counts: the counts
+        :type counts: np.array
+        :param remove_outliers: whether to remove outliers
+        :type remove_outliers: bool
+        :param outlier_mask: the outlier mask
+        :type outlier_mask: np.array
+        :return: the epoch
+        :rtype: float
+        """
         # TODO: add doc
         u_lims = pd.isna(e)
         nan_mask = pd.isna(f)


### PR DESCRIPTION
Speed up the binning by `WiseDataByVisit` significantly by replacing the loop over epochs by `numpy.digitize` and `numpy.bincount`. Results remain the same.
[check_lc2_flux.pdf](https://github.com/JannisNe/timewise/files/10237050/check_lc2_flux.pdf)
[check_lc2_flux_density.pdf](https://github.com/JannisNe/timewise/files/10237051/check_lc2_flux_density.pdf)
[check_lc2_mag.pdf](https://github.com/JannisNe/timewise/files/10237052/check_lc2_mag.pdf)
[check_lc2_ratios.pdf](https://github.com/JannisNe/timewise/files/10237053/check_lc2_ratios.pdf)
[metadata_check.pdf](https://github.com/JannisNe/timewise/files/10237054/metadata_check.pdf)
