### PR TITLE
Add option to get additional columns when matching to WISE

### DIFF
--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -103,7 +103,7 @@ class TestMIRFlareCatalogue(unittest.TestCase):
     def test_a_wise_data(self):
         logger.info('\n\n Testing WISE Data \n')
         wise_data = WISEDataTestVersion()
-        wise_data.match_all_chunks()
+        wise_data.match_all_chunks(additional_columns=["w1mpro"])
 
         logger.info('\n' + wise_data.parent_sample.df.to_string())
 


### PR DESCRIPTION
Add `additional_columns` to `WISEDataBase.match_all_chunks()`. This should be a list of columns names that will be downloaded from the WISE catalogue next to `cntr` and `id`.