### PR TITLE
If files are missing, do not combine and raise warning

### DIFF
--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -736,6 +736,11 @@ class WISEDataBase(abc.ABC):
                 for fn in tqdm.tqdm(fns, desc="removing files"):
                     os.remove(fn)
 
+            return True
+
+        else:
+            return False
+
     # ----------------------------------------------------------------------------------- #
     # START using GATOR to get photometry        #
     # ------------------------------------------ #

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -683,8 +683,7 @@ class WISEDataBase(abc.ABC):
             service=None,
             chunk_number=None,
             remove=False,
-            overwrite=False,
-            require_n_files=None
+            overwrite=False
     ):
         if not service:
             logger.info("Combining all lightcuves collected with all services")


### PR DESCRIPTION
We know which files we expect to find when calling `WISEDataBase._combine_data_products()`. So now, if one of the calls of `WISEDataBase.load_data_product()` return `None`, i.e. when the file does not exist, we break and log a warning. This will leave the other files where they are. 
`WiseBigDataDESYCluster._combining_thread()` now checks the success of combining.