### PR TITLE
Speed up position masks

### DIFF
--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -1532,7 +1532,7 @@ class WISEDataBase(abc.ABC):
 
             position_masks = dict()
 
-            for i in unbinned_lcs[self._tap_orig_id_key].unique():
+            for i in tqdm.tqdm(unbinned_lcs[self._tap_orig_id_key].unique(), "calculating position masks"):
                 lightcurve = unbinned_lcs[unbinned_lcs[self._tap_orig_id_key] == i]
                 bad_indices = self.calculate_position_mask(lightcurve)
                 if len(bad_indices) > 0:


### PR DESCRIPTION
Avoid using `astropy` in `WISEDataBase.calculate_position_mask()` but instead calculate separations manually. Results are consistent.