### PR TITLE
Verify lightcurves exist when merging files

### DIFF
--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -78,6 +78,14 @@ class WISEBigDataLocal(WISEDataDESYCluster):
 
         logger.debug(f"Jobs from {_start_id} to {_end_id}")
 
+        # make data_product files, storing essential info from parent_sample
+        for jobID in range(_start_id, _end_id+1):
+            indices = self.parent_sample.df.index[self.cluster_jobID_map == jobID]
+            logger.debug(f"starting data_product for {len(indices)} objects.")
+            data_product = self._start_data_product(parent_sample_indices=indices)
+            chunk_number = self._get_chunk_number_for_job(jobID)
+            self._save_data_product(data_product, service="tap", chunk_number=chunk_number, jobID=jobID)
+
         for job_id in range(_start_id, _end_id+1):
             logger.debug(f"Job {job_id}")
             chunk_number = self._get_chunk_number_for_job(job_id)

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -91,7 +91,7 @@ class WISEBigDataLocal(WISEDataDESYCluster):
             logger.debug(f"Job {job_id}")
             chunk_number = self._get_chunk_number_for_job(job_id)
 
-            if job_id in self.fails:
+            if (self.fails is not None) and (job_id in self.fails):
                 logger.debug(f"Job {job_id} failed")
                 continue
 

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -56,6 +56,10 @@ class WISEDataTestVersion(WiseDataByVisit):
 
 class WISEBigDataLocal(WISEDataDESYCluster):
 
+    def __init__(self, base_name, parent_sample_class, min_sep_arcsec, n_chunks, fails=0):
+        super().__init__(base_name, parent_sample_class, min_sep_arcsec, n_chunks)
+        self.fails = fails
+
     def submit_to_cluster(
             self,
             node_memory,
@@ -74,9 +78,16 @@ class WISEBigDataLocal(WISEDataDESYCluster):
 
         logger.debug(f"Jobs from {_start_id} to {_end_id}")
 
+        fails = np.random.randint(_start_id, _end_id, self.fails)
+        logger.debug(f"failing jobs {fails}")
+
         for job_id in range(_start_id, _end_id+1):
             logger.debug(f"Job {job_id}")
             chunk_number = self._get_chunk_number_for_job(job_id)
+
+            if job_id in fails:
+                logger.debug(f"Job {job_id} failed")
+                continue
 
             try:
                 self._subprocess_select_and_bin(
@@ -103,11 +114,12 @@ class WISEBigDataTestVersion(WISEBigDataLocal):
 
     base_name = "test/test_mock_desy_bigdata"
 
-    def __init__(self, base_name=base_name):
+    def __init__(self, base_name=base_name, fails=0):
         super().__init__(base_name=base_name,
                          parent_sample_class=MirongParentSample,
                          min_sep_arcsec=8,
-                         n_chunks=2)
+                         n_chunks=2,
+                         fails=fails)
 
 
 ####################################

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -250,11 +250,17 @@ class TestMIRFlareCatalogue(unittest.TestCase):
 
         bigdata_phot_dir = Path(wise_data._cache_photometry_dir.replace(data_dir, bigdata_dir))
         phot_dir = Path(wise_data._cache_photometry_dir)
+
         for f in bigdata_phot_dir.glob("raw_photometry*"):
             if f.is_file():
                 dst = phot_dir / f.name
                 logger.debug(f"copying {f} back to {dst}")
                 shutil.copy(f, dst)
+
+        for f in bigdata_phot_dir.glob("timewise_data_product*"):
+            if f.is_file():
+                logger.debug(f"removing {f}")
+                os.remove(f)
 
         wise_data.get_sample_photometric_data(
             max_nTAPjobs=2,

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -56,7 +56,7 @@ class WISEDataTestVersion(WiseDataByVisit):
 
 class WISEBigDataLocal(WISEDataDESYCluster):
 
-    def __init__(self, base_name, parent_sample_class, min_sep_arcsec, n_chunks, fails=0):
+    def __init__(self, base_name, parent_sample_class, min_sep_arcsec, n_chunks, fails=None):
         super().__init__(base_name, parent_sample_class, min_sep_arcsec, n_chunks)
         self.fails = fails
 
@@ -78,14 +78,11 @@ class WISEBigDataLocal(WISEDataDESYCluster):
 
         logger.debug(f"Jobs from {_start_id} to {_end_id}")
 
-        fails = np.random.randint(_start_id, _end_id, self.fails)
-        logger.debug(f"failing jobs {fails}")
-
         for job_id in range(_start_id, _end_id+1):
             logger.debug(f"Job {job_id}")
             chunk_number = self._get_chunk_number_for_job(job_id)
 
-            if job_id in fails:
+            if job_id in self.fails:
                 logger.debug(f"Job {job_id} failed")
                 continue
 
@@ -238,7 +235,22 @@ class TestMIRFlareCatalogue(unittest.TestCase):
                 load_from_bigdata_dir=True
             )
 
-    def test_d_wise_bigdata_desy_cluster(self):
+    def test_d_emulate_wise_bigdata_fail(self):
+        logger.info("\n\n Emulating WISEBigDataDESYCluster job fails\n\n")
+        wise_data = WISEBigDataTestVersion(fails=1)
+
+        wise_data.get_sample_photometric_data(
+            max_nTAPjobs=2,
+            cluster_jobs_per_chunk=2,
+            query_type="positional",
+            skip_input=True,
+            wait=0,
+            mask_by_position=True
+        )
+
+
+
+    def test_e_wise_bigdata_desy_cluster(self):
         host = socket.gethostname()
         if np.logical_or("ifh.de" in host, ("zeuthen.desy.de" in host) and ("wgs" in host)):
             host_server = "DESY"

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -274,11 +274,14 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         )
 
         # verify that the failed job is not in the data product
-        self.assertRaises(KeyError, wise_data.load_data_product("tap", 0, fail_job, verify_contains_lightcurves=True))
+        with self.assertRaises(KeyError):
+            wise_data.load_data_product("tap", 0, fail_job, verify_contains_lightcurves=True)
+
         # verify that the combined chunk file has not been produced nor moved to the big data directory
         chunk_0_data_product_filename = wise_data._data_product_filename("tap", 0, use_bigdata_dir=False)
         self.assertFalse(os.path.isfile(chunk_0_data_product_filename))
         self.assertFalse(os.path.isfile(chunk_0_data_product_filename.replace(data_dir, bigdata_dir)))
+
         # verify that chunk 1 was processed normally
         chunk1_data_product = wise_data.load_data_product("tap", 1,
                                                           use_bigdata_dir=True,

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -146,10 +146,11 @@ class WISEDataDESYCluster(WiseDataByVisit):
             with gzip.open(fn, 'rt', encoding="utf-8") as fzip:
                 data_product = json.load(fzip)
 
-            try:
-                self._verify_contains_lightcurves(data_product)
-            except KeyError as e:
-                raise KeyError(f"{fn}: {e}")
+            if verify_contains_lightcurves:
+                try:
+                    self._verify_contains_lightcurves(data_product)
+                except KeyError as e:
+                    raise KeyError(f"{fn}: {e}")
 
             if return_filename:
                 return data_product, fn

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -131,7 +131,8 @@ class WISEDataDESYCluster(WiseDataByVisit):
             chunk_number=None,
             jobID=None,
             return_filename=False,
-            use_bigdata_dir=False
+            use_bigdata_dir=False,
+            verify_contains_lightcurves=False
     ):
         fn = self._data_product_filename(
             service,
@@ -144,6 +145,12 @@ class WISEDataDESYCluster(WiseDataByVisit):
         try:
             with gzip.open(fn, 'rt', encoding="utf-8") as fzip:
                 data_product = json.load(fzip)
+
+            if verify_contains_lightcurves:
+                mask = ["timewise_lightcurve" in data.keys() for data in data_product.values()]
+                if not any(mask):
+                    raise AttributeError(f"No lightcurves found! Cluster job probably did not finish. {fn}")
+
             if return_filename:
                 return data_product, fn
             return data_product

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -146,10 +146,10 @@ class WISEDataDESYCluster(WiseDataByVisit):
             with gzip.open(fn, 'rt', encoding="utf-8") as fzip:
                 data_product = json.load(fzip)
 
-            if verify_contains_lightcurves:
-                mask = ["timewise_lightcurve" in data.keys() for data in data_product.values()]
-                if not any(mask):
-                    raise AttributeError(f"No lightcurves found! Cluster job probably did not finish. {fn}")
+            try:
+                self._verify_contains_lightcurves(data_product)
+            except KeyError as e:
+                raise KeyError(f"{fn}: {e}")
 
             if return_filename:
                 return data_product, fn

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -725,6 +725,13 @@ class WISEDataBase(abc.ABC):
             else:
                 return os.path.join(self._cache_photometry_dir, fn + f"_{jobID}.json")
 
+    @staticmethod
+    def _verify_contains_lightcurves(data_product):
+        mask = ["timewise_lightcurve" in data.keys() for data in data_product.values()]
+        if not any(mask):
+            raise KeyError(f"'timewise_lightcurves' in none of the results."
+                           f"Cluster job probably did not finish.")
+
     def load_data_product(self, service, chunk_number=None, jobID=None, return_filename=False):
         """
         Load data product from disk

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -811,16 +811,16 @@ class WISEDataBase(abc.ABC):
 
             try:
                 res = self.load_data_product(**kw)
-                ilcs, ifn = res
-                fns.append(ifn)
-                if isinstance(lcs, type(None)):
-                    lcs = dict(ilcs)
-                else:
-                    lcs.update(ilcs)
+                if res is not None:
+                    ilcs, ifn = res
+                    fns.append(ifn)
+                    if isinstance(lcs, type(None)):
+                        lcs = dict(ilcs)
+                    else:
+                        lcs.update(ilcs)
 
-            except FileNotFoundError as e:
-                logger.error(e)
-                missing_files = True
+                else:
+                    missing_files = True
 
             except KeyError as e:
                 logger.error(e)

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -750,6 +750,9 @@ class WISEDataBase(abc.ABC):
         :param jobID: jobID to load, if None load the combined file for this chunk
         :type jobID: int, optional
         :param return_filename: return filename of data product, defaults to False
+        :type return_filename: bool, optional
+        :param verify_contains_lightcurves: verify that the data product contains lightcurves, defaults to False
+        :type verify_contains_lightcurves: bool, optional
         """
         fn = self._data_product_filename(service, chunk_number, jobID)
         logger.debug(f"loading {fn}")

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -749,6 +749,10 @@ class WISEDataBase(abc.ABC):
         try:
             with open(fn, "r") as f:
                 lcs = json.load(f)
+            try:
+                self._verify_contains_lightcurves(lcs)
+            except KeyError as e:
+                raise KeyError(f"{fn}: {e}")
             if return_filename:
                 return lcs, fn
             return lcs

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -732,7 +732,14 @@ class WISEDataBase(abc.ABC):
             raise KeyError(f"'timewise_lightcurves' in none of the results."
                            f"Cluster job probably did not finish.")
 
-    def load_data_product(self, service, chunk_number=None, jobID=None, return_filename=False):
+    def load_data_product(
+            self,
+            service,
+            chunk_number=None,
+            jobID=None,
+            return_filename=False,
+            verify_contains_lightcurves=False
+    ):
         """
         Load data product from disk
 
@@ -749,10 +756,13 @@ class WISEDataBase(abc.ABC):
         try:
             with open(fn, "r") as f:
                 lcs = json.load(f)
-            try:
-                self._verify_contains_lightcurves(lcs)
-            except KeyError as e:
-                raise KeyError(f"{fn}: {e}")
+
+            if verify_contains_lightcurves:
+                try:
+                    self._verify_contains_lightcurves(lcs)
+                except KeyError as e:
+                    raise KeyError(f"{fn}: {e}")
+
             if return_filename:
                 return lcs, fn
             return lcs
@@ -808,6 +818,7 @@ class WISEDataBase(abc.ABC):
             kw = dict(kwargs)
             kw[itr[0]] = i
             kw['return_filename'] = True
+            kw["verify_contains_lightcurves"] = True
 
             try:
                 res = self.load_data_product(**kw)


### PR DESCRIPTION
Add the keyword `verify_contains_lightcurves` to `WISEDataBase.load_data_product()` and `WISEDataDESYCluster.load_data_product()` that raises a `KeyError` when no `timewise_lightcurves` are in the data product, indicating that a sub-process or a cluster job failed. In that case, the combining of the files for the corresponding chunks will not happen.