### PR TITLE
Cache TAP jobs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,13 +7,8 @@
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
+# add these directories to sys.path here.
 import sphinx_rtd_theme
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------

--- a/tests/test_0_test_config.py
+++ b/tests/test_0_test_config.py
@@ -3,8 +3,8 @@ import logging
 import pandas as pd
 from pathlib import Path
 
-from timewise.general import main_logger, cache_dir
-from timewise.utils import get_mirong_sample, local_copy
+from timewise.general import get_directories, main_logger
+from timewise.utils import get_mirong_sample, get_mirong_path
 from timewise.config_loader import TimewiseConfigLoader
 
 
@@ -13,14 +13,14 @@ logger = logging.getLogger("timewise.test")
 
 
 def get_test_yaml_filename():
-    dir_path = Path(cache_dir)
-    return dir_path / "test" / "test_config" / "test.yml"
+    return get_directories()["cache_dir"] / "test" / "test_config" / "test.yml"
 
 
 def make_test_yaml():
+    mirong_path = get_mirong_path()
     txt = (
         f"base_name: mirong_test \n"
-        f"filename: {local_copy} \n"
+        f"filename: {mirong_path} \n"
         f"default_keymap: \n"
         f" ra: RA \n"
         f" dec: DEC \n"
@@ -49,7 +49,7 @@ class TestConfig(unittest.TestCase):
         logger.info("\n\n Testing TimewiseConfig \n")
         TimewiseConfigLoader.run_yaml(get_test_yaml_filename())
         logger.info("checking result")
-        fn = Path(cache_dir) / "mirong_test" / "sample.csv"
+        fn = get_directories()["cache_dir"] / "mirong_test" / "sample.csv"
         df = pd.read_csv(fn)
         self.assertTrue("w1mpro" in df.columns)
         self.assertTrue("w2mpro" in df.columns)

--- a/tests/test_0_test_config.py
+++ b/tests/test_0_test_config.py
@@ -1,7 +1,6 @@
 import unittest
 import logging
 import pandas as pd
-from pathlib import Path
 
 from timewise.general import get_directories, main_logger
 from timewise.utils import get_mirong_sample, get_mirong_path

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -5,6 +5,7 @@ import socket
 import numpy as np
 import logging
 from pathlib import Path
+import time
 
 from timewise import WiseDataByVisit, WISEDataDESYCluster, ParentSampleBase
 from timewise.general import main_logger, get_directories
@@ -149,7 +150,13 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         for s in ['gator', 'tap']:
 
             logger.info(f"\nTesting {s.upper()}")
-            wise_data.get_photometric_data(service=s, mask_by_position=True)
+            success = wise_data.get_photometric_data(service=s, mask_by_position=True)
+
+            if (s == "tap") and (not success):
+                logger.info("TAP jobs running, waiting 60 seconds and trying again")
+                time.sleep(60)
+                success = wise_data.get_photometric_data(service=s, mask_by_position=True)
+            self.assertTrue(success, f"{s} photometry download failed")
 
             logger.info(f" --- Test adding flux densities --- ")
             wise_data.add_flux_densities_to_saved_lightcurves(s)

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -283,7 +283,10 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         wise_data = WISEBigDataTestVersion(fails=[fail_job])
         d = get_directories()
 
-        bigdata_phot_dir = Path(wise_data._cache_photometry_dir.replace(d["data_dir"], d["bigdata_dir"]))
+        bigdata_phot_dir = Path(str(wise_data._cache_photometry_dir).replace(
+            str(d["data_dir"]),
+            str(d["bigdata_dir"]))
+        )
         phot_dir = Path(wise_data._cache_photometry_dir)
 
         for f in bigdata_phot_dir.glob("raw_photometry*"):

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 
 from timewise import WiseDataByVisit, WISEDataDESYCluster, ParentSampleBase
-from timewise.general import main_logger, data_dir, bigdata_dir
+from timewise.general import main_logger, get_directories
 from timewise.utils import get_mirong_sample
 
 
@@ -164,7 +164,7 @@ class TestMIRFlareCatalogue(unittest.TestCase):
             lcs = wise_data.load_data_product(s)
             plot_id = list(lcs.keys())[0].split('_')[0]
             for lumk in ['mag', 'flux_density', 'luminosity']:
-                fn = os.path.join(wise_data.plots_dir, f"{plot_id}_{lumk}.pdf")
+                fn = wise_data.plots_dir / f"{plot_id}_{lumk}.pdf"
                 plot_unbinned = True if lumk == 'mag' else False
                 wise_data.plot_lc(
                     parent_sample_idx=plot_id,
@@ -181,8 +181,8 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         wise_data = WISEDataTestVersion(
             base_name=WISEDataTestVersion.base_name + '_match_to_allsky'
         )
-        in_filename = os.path.join(wise_data.cache_dir, "test_allsky_match_in.xml")
-        out_filename = os.path.join(wise_data.cache_dir, "test_allsky_match_out.tbl")
+        in_filename = wise_data.cache_dir / "test_allsky_match_in.xml"
+        out_filename = wise_data.cache_dir / "test_allsky_match_out.tbl"
         mask = [True] * len(wise_data.parent_sample.df)
         res = wise_data._match_to_wise(
             table_name=wise_data.get_db_name("WISE All-Sky Source Catalog"),
@@ -222,7 +222,7 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         lcs = wise_data.load_data_product(s)
         plot_id = list(lcs.keys())[0].split('_')[0]
         for lumk in ['mag', 'flux_density', 'luminosity']:
-            fn = os.path.join(wise_data.plots_dir, f"{plot_id}_{lumk}.pdf")
+            fn = wise_data.plots_dir / f"{plot_id}_{lumk}.pdf"
             plot_unbinned = True if lumk == 'mag' else False
             wise_data.plot_lc(
                 parent_sample_idx=plot_id,
@@ -253,7 +253,7 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         logger.info(f" --- Test plot lightcurves --- ")
         plot_id = "2"
         for lumk in ['mag', 'flux_density']:
-            fn = os.path.join(wise_data.plots_dir, f"{plot_id}_{lumk}.pdf")
+            fn = wise_data.plots_dir / f"{plot_id}_{lumk}.pdf"
             wise_data.plot_lc(
                 parent_sample_idx=plot_id,
                 lum_key=lumk,
@@ -297,8 +297,10 @@ class TestMIRFlareCatalogue(unittest.TestCase):
 
         # verify that the combined chunk file has not been produced nor moved to the big data directory
         chunk_0_data_product_filename = wise_data._data_product_filename("tap", 0, use_bigdata_dir=False)
-        self.assertFalse(os.path.isfile(chunk_0_data_product_filename))
-        self.assertFalse(os.path.isfile(chunk_0_data_product_filename.replace(data_dir, bigdata_dir)))
+        self.assertFalse(chunk_0_data_product_filename.is_file())
+        ds = get_directories()
+        d2 = Path(str(chunk_0_data_product_filename).replace(str(ds["data_dir"]), str(ds["bigdata_dir"])))
+        self.assertFalse(d2.is_file())
 
         # verify that chunk 1 was processed normally
         chunk1_data_product = wise_data.load_data_product("tap", 1,

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -154,7 +154,7 @@ class TestMIRFlareCatalogue(unittest.TestCase):
 
             if (s == "tap") and (not success):
                 logger.info("TAP jobs running, waiting 60 seconds and trying again")
-                time.sleep(60)
+                time.sleep(10)
                 success = wise_data.get_photometric_data(service=s, mask_by_position=True)
             self.assertTrue(success, f"{s} photometry download failed")
 
@@ -210,11 +210,19 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         s = 'tap'
 
         logger.info(f"\nTesting {s.upper()} and query type 'by_allwise_id'")
-        wise_data.get_photometric_data(
+        success = wise_data.get_photometric_data(
             service=s,
             query_type='by_allwise_id',
             tables=["AllWISE Multiepoch Photometry Table"]
         )
+        if (s == 'tap') and (not success):
+            logger.info("giving TAP jobs some time")
+            time.sleep(10)
+            wise_data.get_photometric_data(
+                service=s,
+                query_type='by_allwise_id',
+                tables=["AllWISE Multiepoch Photometry Table"]
+            )
 
         logger.info(f" --- Test adding flux densities --- ")
         wise_data.add_flux_densities_to_saved_lightcurves(s)

--- a/tests/test_1_test_download.py
+++ b/tests/test_1_test_download.py
@@ -266,8 +266,9 @@ class TestMIRFlareCatalogue(unittest.TestCase):
         logger.info("\n\n Emulating WISEBigDataDESYCluster job fails\n\n")
         fail_job = 1
         wise_data = WISEBigDataTestVersion(fails=[fail_job])
+        d = get_directories()
 
-        bigdata_phot_dir = Path(wise_data._cache_photometry_dir.replace(data_dir, bigdata_dir))
+        bigdata_phot_dir = Path(wise_data._cache_photometry_dir.replace(d["data_dir"], d["bigdata_dir"]))
         phot_dir = Path(wise_data._cache_photometry_dir)
 
         for f in bigdata_phot_dir.glob("raw_photometry*"):

--- a/timewise/big_parent_sample.py
+++ b/timewise/big_parent_sample.py
@@ -1,5 +1,4 @@
 import gc
-import os
 import pickle
 import threading
 import time
@@ -30,7 +29,7 @@ class BigParentSampleBase(ParentSampleBase):
         self._keep_df_in_memory = keep_file_in_memory
         self._time_when_df_was_used_last = time.time()
         self._df = None
-        self._cache_file = os.path.join(self.cache_dir, "cache.pkl")
+        self._cache_file = self.cache_dir / "cache.pkl"
         self._lock_cache_file = False
 
         self._clean_thread = threading.Thread(target=self._periodically_drop_df_to_disk, daemon=True, name='ParentSampleCleanThread').start()
@@ -50,7 +49,7 @@ class BigParentSampleBase(ParentSampleBase):
 
         if isinstance(self._df, type(None)):
 
-            if os.path.isfile(self._cache_file):
+            if self._cache_file.is_file():
                 logger.debug(f'loading from {self._cache_file}')
                 self._wait_for_unlock_cache_file()
                 self._lock_cache_file = True
@@ -97,9 +96,9 @@ class BigParentSampleBase(ParentSampleBase):
         logger.debug('stopped clean thread')
 
     def __del__(self):
-        if hasattr(self, "_cache_file") and os.path.isfile(self._cache_file):
+        if hasattr(self, "_cache_file") and self._cache_file.is_file():
             logger.debug(f'removing {self._cache_file}')
-            os.remove(self._cache_file)
+            self._cache_file.unlink()
 
         if hasattr(self, "clean_thread"):
             logger.debug(f'stopping clean thread')

--- a/timewise/config_loader.py
+++ b/timewise/config_loader.py
@@ -1,11 +1,11 @@
 import logging
 import yaml
 import json
-import os
 import inspect
 from pydantic import BaseModel, validator
 import pandas as pd
 import importlib
+from pathlib import Path
 
 from timewise.parent_sample_base import ParentSampleBase
 from timewise.wise_data_base import WISEDataBase
@@ -80,7 +80,7 @@ class TimewiseConfigLoader(BaseModel):
     @validator("filename")
     def validate_file(cls, v: str):
         if v is not None:
-            if not os.path.isfile(v):
+            if not Path(v).is_file():
                 raise ValueError(f"No file {v}!")
         return v
 

--- a/timewise/general.py
+++ b/timewise/general.py
@@ -1,4 +1,6 @@
-import logging, os
+import logging
+import os
+from pathlib import Path
 
 
 # Setting up the Logger
@@ -13,29 +15,35 @@ main_logger.propagate = False  # do not propagate to root logger
 
 logger = logging.getLogger(__name__)
 
-# Setting up data directory
-DATA_DIR_KEY = 'TIMEWISE_DATA'
-if DATA_DIR_KEY in os.environ:
-    data_dir = os.path.expanduser(os.environ[DATA_DIR_KEY])
-else:
-    logger.warning(f'{DATA_DIR_KEY} not set! Using home directory.')
-    data_dir = os.path.expanduser('~/')
 
-BIGDATA_DIR_KEY = 'TIMEWISE_BIGDATA'
-if BIGDATA_DIR_KEY in os.environ:
-    bigdata_dir = os.path.expanduser(os.environ[BIGDATA_DIR_KEY])
-    logger.info(f"Using bigdata directory {bigdata_dir}")
-else:
-    bigdata_dir = None
-    logger.info(f"No bigdata directory set.")
+def get_directories() -> dict[str, Path | None]:
+    # Setting up data directory
+    DATA_DIR_KEY = 'TIMEWISE_DATA'
+    if DATA_DIR_KEY in os.environ:
+        data_dir = Path(os.environ[DATA_DIR_KEY]).expanduser()
+    else:
+        logger.warning(f'{DATA_DIR_KEY} not set! Using home directory.')
+        data_dir = Path('~/').expanduser()
 
-output_dir = os.path.join(data_dir, 'output')
-plots_dir = os.path.join(output_dir, 'plots')
-cache_dir = os.path.join(data_dir, 'cache')
+    BIGDATA_DIR_KEY = 'TIMEWISE_BIGDATA'
+    if BIGDATA_DIR_KEY in os.environ:
+        bigdata_dir = Path(os.environ[BIGDATA_DIR_KEY]).expanduser()
+        logger.info(f"Using bigdata directory {bigdata_dir}")
+    else:
+        bigdata_dir = None
+        logger.info(f"No bigdata directory set.")
 
-for d in [data_dir, output_dir, plots_dir, cache_dir]:
-    if not os.path.isdir(d):
-        os.mkdir(os.path.abspath(d))
+    output_dir = data_dir / 'output'
+    plots_dir = output_dir / 'plots'
+    cache_dir = data_dir / 'cache'
+
+    return {
+        'data_dir': data_dir,
+        'bigdata_dir': bigdata_dir,
+        'output_dir': output_dir,
+        'plots_dir': plots_dir,
+        'cache_dir': cache_dir
+    }
 
 
 def backoff_hndlr(details):

--- a/timewise/parent_sample_base.py
+++ b/timewise/parent_sample_base.py
@@ -57,6 +57,7 @@ class ParentSampleBase(abc.ABC):
             [self.plots_dir / f"{i}_{r[self.default_keymap['id']]}.pdf"
              for i, r in sel.iterrows()]
         )
+        self.plots_dir.mkdir(parents=True, exist_ok=True)
 
         logger.debug(f"\nRA: {ra}\nDEC: {dec}\nTITLE: {title}\nFN: {fn}")
         ou = list()

--- a/timewise/parent_sample_base.py
+++ b/timewise/parent_sample_base.py
@@ -84,4 +84,5 @@ class ParentSampleBase(abc.ABC):
 
     def save_local(self):
         logger.debug(f"saving under {self.local_sample_copy}")
+        self.local_sample_copy.parent.mkdir(parents=True, exist_ok=True)
         self.df.to_csv(self.local_sample_copy)

--- a/timewise/parent_sample_base.py
+++ b/timewise/parent_sample_base.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import logging
 
-from timewise.general import cache_dir, plots_dir
+from timewise.general import get_directories
 from timewise.utils import plot_sdss_cutout, plot_panstarrs_cutout
 
 
@@ -26,14 +26,14 @@ class ParentSampleBase(abc.ABC):
 
     def __init__(self, base_name):
         # set up directories
-        self.cache_dir = os.path.join(cache_dir, base_name)
-        self.plots_dir = os.path.join(plots_dir, base_name)
+        d = get_directories()
+        self.cache_dir = d["cache_dir"] / base_name
+        self.plots_dir = d["plots_dir"] / base_name
 
         for d in [self.cache_dir, self.plots_dir]:
-            if not os.path.isdir(d):
-                os.makedirs(d)
+            d.parent.mkdir(parents=True, exist_ok=True)
 
-        self.local_sample_copy = os.path.join(self.cache_dir, 'sample.csv')
+        self.local_sample_copy = self.cache_dir / 'sample.csv'
 
     def plot_cutout(self, ind, arcsec=20, interactive=False, **kwargs):
         """
@@ -54,7 +54,7 @@ class ParentSampleBase(abc.ABC):
 
         fn = kwargs.pop(
             "fn",
-            [os.path.join(self.plots_dir, f"{i}_{r[self.default_keymap['id']]}.pdf")
+            [self.plots_dir / f"{i}_{r[self.default_keymap['id']]}.pdf"
              for i, r in sel.iterrows()]
         )
 

--- a/timewise/utils.py
+++ b/timewise/utils.py
@@ -158,7 +158,7 @@ def load_cache_or_download(url):
     logger.debug(f"loading or downloading {url}")
     h = hashlib.md5(url.encode()).hexdigest()
     cache_dir = get_directories()['cache_dir']
-    cache_file = cache_dir / h + ".cache"
+    cache_file = cache_dir / (h + ".cache")
     logger.debug(f"cache file is {cache_file}")
     if not cache_file.is_file:
         logger.debug(f"downloading {url}")

--- a/timewise/utils.py
+++ b/timewise/utils.py
@@ -14,13 +14,15 @@ from PIL import Image
 from io import BytesIO
 import hashlib
 
-
-from timewise.general import cache_dir, backoff_hndlr
+from timewise.general import backoff_hndlr, get_directories
 
 
 logger = logging.getLogger(__name__)
 mirong_url = 'http://staff.ustc.edu.cn/~jnac/data_public/wisevar.txt'
-local_copy = os.path.join(cache_dir, 'mirong_sample.csv')
+
+
+def get_mirong_path():
+    return get_directories()['cache_dir'] / 'mirong_sample.csv'
 
 
 @cache
@@ -30,7 +32,8 @@ def get_2d_gaussian_correction(cl):
 
 def get_mirong_sample():
 
-    if not os.path.isfile(local_copy):
+    mirong_path = get_mirong_path()
+    if not mirong_path.is_file():
 
         logger.info(f'getting MIRONG sample from {mirong_url}')
         r = requests.get(mirong_url)
@@ -45,16 +48,16 @@ def get_mirong_sample():
         mirong_sample = pd.DataFrame(lll[1:-1], columns=lll[0])
         mirong_sample['ra'] = mirong_sample['RA']
         mirong_sample['dec'] = mirong_sample['DEC']
-        logger.debug(f'saving to {local_copy}')
+        logger.debug(f'saving to {mirong_path}')
 
-        mirong_sample.to_csv(local_copy, index=False)
+        mirong_sample.to_csv(mirong_path, index=False)
         logger.info(f'found {len(mirong_sample)} objects in MIRONG Sample')
         mirong_sample.drop(columns=['ra', 'dec'], inplace=True)
-        mirong_sample.to_csv(local_copy, index=False)
+        mirong_sample.to_csv(mirong_path, index=False)
 
     else:
-        logger.debug(f'loading {local_copy}')
-        mirong_sample = pd.read_csv(local_copy)
+        logger.debug(f'loading {mirong_path}')
+        mirong_sample = pd.read_csv(mirong_path)
 
     return mirong_sample
 
@@ -154,9 +157,10 @@ class PanSTARRSQueryError(Exception):
 def load_cache_or_download(url):
     logger.debug(f"loading or downloading {url}")
     h = hashlib.md5(url.encode()).hexdigest()
-    cache_file = os.path.join(cache_dir, h + ".cache")
+    cache_dir = get_directories()['cache_dir']
+    cache_file = cache_dir / h + ".cache"
     logger.debug(f"cache file is {cache_file}")
-    if not os.path.isfile(cache_file):
+    if not cache_file.is_file:
         logger.debug(f"downloading {url}")
         r = requests.get(url)
         with open(cache_file, 'wb') as f:

--- a/timewise/utils.py
+++ b/timewise/utils.py
@@ -48,11 +48,10 @@ def get_mirong_sample():
         mirong_sample = pd.DataFrame(lll[1:-1], columns=lll[0])
         mirong_sample['ra'] = mirong_sample['RA']
         mirong_sample['dec'] = mirong_sample['DEC']
-        logger.debug(f'saving to {mirong_path}')
-
-        mirong_sample.to_csv(mirong_path, index=False)
         logger.info(f'found {len(mirong_sample)} objects in MIRONG Sample')
+
         mirong_sample.drop(columns=['ra', 'dec'], inplace=True)
+        logger.debug(f'saving to {mirong_path}')
         mirong_path.parent.mkdir(parents=True, exist_ok=True)
         mirong_sample.to_csv(mirong_path, index=False)
 

--- a/timewise/utils.py
+++ b/timewise/utils.py
@@ -53,6 +53,7 @@ def get_mirong_sample():
         mirong_sample.to_csv(mirong_path, index=False)
         logger.info(f'found {len(mirong_sample)} objects in MIRONG Sample')
         mirong_sample.drop(columns=['ra', 'dec'], inplace=True)
+        mirong_path.parent.mkdir(parents=True, exist_ok=True)
         mirong_sample.to_csv(mirong_path, index=False)
 
     else:

--- a/timewise/utils.py
+++ b/timewise/utils.py
@@ -13,6 +13,9 @@ from astropy.table import Table
 from PIL import Image
 from io import BytesIO
 import hashlib
+from threading import Thread
+from queue import Queue
+import sys
 
 from timewise.general import backoff_hndlr, get_directories
 
@@ -469,3 +472,47 @@ class StableTAPService(vo.dal.TAPService):
 #######################################################
 #            END CUSTOM TAP Service                   #
 ###########################################################################################################
+
+
+###########################################################################################################
+#            START CUSTOM TAP Service                 #
+#######################################################
+
+
+class ErrorQueue(Queue):
+    """Queue subclass whose join() re-raises exceptions from worker threads."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.error_queue = Queue()
+
+    def report_error(self, exc_info):
+        """Called by workers to push an exception into the error queue."""
+        self.error_queue.put(exc_info)
+        # Also decrement unfinished_tasks, so join() won't block forever
+        with self.all_tasks_done:
+            self.unfinished_tasks = max(0, self.unfinished_tasks - 1)
+            self.all_tasks_done.notify_all()
+
+    def join(self):
+        """Wait until all tasks are done, or raise if a worker failed."""
+        with self.all_tasks_done:
+            while self.unfinished_tasks:
+                if not self.error_queue.empty():
+                    exc_info = self.error_queue.get()
+                    raise exc_info[1].with_traceback(exc_info[2])
+                self.all_tasks_done.wait()
+
+
+class ExceptionSafeThread(Thread):
+    """Thread subclass that reports uncaught exceptions to the ErrorQueue."""
+
+    def __init__(self, error_queue: ErrorQueue, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.error_queue = error_queue
+
+    def run(self):
+        try:
+            super().run()
+        except Exception:
+            self.error_queue.report_error(sys.exc_info())

--- a/timewise/utils.py
+++ b/timewise/utils.py
@@ -160,7 +160,7 @@ def load_cache_or_download(url):
     cache_dir = get_directories()['cache_dir']
     cache_file = cache_dir / (h + ".cache")
     logger.debug(f"cache file is {cache_file}")
-    if not cache_file.is_file:
+    if not cache_file.is_file():
         logger.debug(f"downloading {url}")
         r = requests.get(url)
         with open(cache_file, 'wb') as f:

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -477,7 +477,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
 
     def _move_file_to_storage(self, filename):
         data_dir = str(get_directories()['data_dir'])
-        dst_fn = Path(filename.replace(data_dir, self._storage_dir))
+        dst_fn = Path(str(filename).replace(str(data_dir), str(self._storage_dir)))
         dst_fn.parent.mkdir(parents=True, exist_ok=True)
 
         logger.debug(f"copy {filename} to {dst_fn}")

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -129,7 +129,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
             d = get_directories()
             fn = fn.replace(d["data_dir"], d["bigdata_dir"])
 
-        return fn + ".gz"
+        return Path(str(fn) + ".gz")
 
     def load_data_product(
             self,

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -711,7 +711,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
         """
         Clears the directory where cluster logs are stored
         """
-        fns = self.cluster_log_dir.glob()
+        fns = self.cluster_log_dir.glob("*")
         for fn in fns:
             (self.cluster_log_dir / fn).unlink()
 

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -15,6 +15,7 @@ import shutil
 import gc
 import tqdm
 import sys
+from pathlib import Path
 
 from functools import cache
 from scipy.stats import chi2, f
@@ -28,7 +29,7 @@ import logging
 
 from typing import List
 
-from timewise.general import data_dir, bigdata_dir, backoff_hndlr
+from timewise.general import get_directories, backoff_hndlr
 from timewise.wise_data_by_visit import WiseDataByVisit
 
 
@@ -41,9 +42,9 @@ class WISEDataDESYCluster(WiseDataByVisit):
     In addition to the attributes of `WiseDataByVisit` this class has the following attributes:
 
     :param executable_filename: the filename of the executable that will be submitted to the cluster
-    :type executable_filename: str
+    :type executable_filename: Path
     :param submit_file_filename: the filename of the submit file that will be submitted to the cluster
-    :type submit_file_filename: str
+    :type submit_file_filename: Path
     :param job_id: the job id of the submitted job
     :type job_id: str
     :param cluster_jobID_map: a dictionary mapping the chunk number to the cluster job id
@@ -51,13 +52,16 @@ class WISEDataDESYCluster(WiseDataByVisit):
     :param clusterJob_chunk_map: a dictionary mapping the cluster job id to the chunk number
     :type clusterJob_chunk_map: dict
     :param cluster_info_file: the filename of the file that stores the cluster info, loaded by the cluster jobs
-    :type cluster_info_file: str
+    :type cluster_info_file: Path
     :param start_time: the time when the download started
     :type start_time: float
     """
     status_cmd = f'qstat -u {getpass.getuser()}'
     # finding the file that contains the setup function
-    BASHFILE = os.getenv('TIMEWISE_DESY_CLUSTER_BASHFILE', os.path.expanduser('~/.bashrc'))
+    if (env_file := os.getenv('TIMEWISE_DESY_CLUSTER_BASHFILE')) is not None:
+        BASHFILE = Path(env_file)
+    else:
+        BASHFILE = Path("~/.bashrc").expanduser()
 
     def __init__(
             self,
@@ -89,13 +93,14 @@ class WISEDataDESYCluster(WiseDataByVisit):
 
         # set up cluster stuff
         self._status_output = None
-        self.executable_filename = os.path.join(self.cluster_dir, "run_timewise.sh")
-        self.submit_file_filename = os.path.join(self.cluster_dir, "submit_file.submit")
+        directories = get_directories()
+        self.executable_filename = self.cluster_dir / "run_timewise.sh"
+        self.submit_file_filename = self.cluster_dir / "submit_file.submit"
         self.job_id = None
 
         self.cluster_jobID_map = None
         self.clusterJob_chunk_map = None
-        self.cluster_info_file = os.path.join(self.cluster_dir, 'cluster_info.pkl')
+        self.cluster_info_file = self.cluster_dir / 'cluster_info.pkl'
         self._overwrite = True
 
         # these attributes will be set later and are used to pass them to the threads
@@ -121,7 +126,8 @@ class WISEDataDESYCluster(WiseDataByVisit):
         fn = super(WISEDataDESYCluster, self)._data_product_filename(service, chunk_number=chunk_number, jobID=jobID)
 
         if use_bigdata_dir:
-            fn = fn.replace(data_dir, bigdata_dir)
+            d = get_directories()
+            fn = fn.replace(d["data_dir"], d["bigdata_dir"])
 
         return fn + ".gz"
 
@@ -199,7 +205,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
     def get_sample_photometric_data(self, max_nTAPjobs=8, perc=1, tables=None, chunks=None,
                                     cluster_jobs_per_chunk=100, wait=5, remove_chunks=False,
                                     query_type='positional', overwrite=True,
-                                    storage_directory=bigdata_dir,
+                                    storage_directory=None,
                                     node_memory='8G',
                                     skip_download=False,
                                     skip_input=False,
@@ -225,8 +231,8 @@ class WISEDataDESYCluster(WiseDataByVisit):
         :type query_type: str
         :param overwrite: overwrite already existing lightcurves and metadata
         :type overwrite: bool
-        :param storage_directory: move binned files and raw data here after work is done
-        :type storage_directory: str
+        :param storage_directory: move binned files and raw data here after work is done, defaults to TIMEWISE_BIGDATA_DIR
+        :type storage_directory: str | Path
         :param node_memory: memory per node on the cluster, default is 8G
         :type node_memory: str
         :param skip_download: if True, assume data is already downloaded, only do binning in that case
@@ -281,7 +287,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
         self.clear_cluster_log_dir()
         self._save_cluster_info()
         self._overwrite = overwrite
-        self._storage_dir = storage_directory
+        self._storage_dir = get_directories()['bigdata_dir'] if storage_directory is None else Path(storage_directory)
 
         # --------------------------- set up queues --------------------------- #
 
@@ -466,19 +472,16 @@ class WISEDataDESYCluster(WiseDataByVisit):
             gc.collect()
 
     def _move_file_to_storage(self, filename):
-        dst_fn = filename.replace(data_dir, self._storage_dir)
-
-        dst_dir = os.path.dirname(dst_fn)
-        if not os.path.isdir(dst_dir):
-            logger.debug(f"making directory {dst_dir}")
-            os.makedirs(dst_dir)
+        data_dir = str(get_directories()['data_dir'])
+        dst_fn = Path(filename.replace(data_dir, self._storage_dir))
+        dst_fn.parent.mkdir(parents=True, exist_ok=True)
 
         logger.debug(f"copy {filename} to {dst_fn}")
 
         try:
             shutil.copy2(filename, dst_fn)
 
-            if os.path.getsize(filename) == os.path.getsize(dst_fn):
+            if Path(filename).stat().st_size == dst_fn.stat().st_size:
                 logger.debug(f"copy successful, removing {filename}")
                 os.remove(filename)
             else:
@@ -509,8 +512,8 @@ class WISEDataDESYCluster(WiseDataByVisit):
                 self.wait_for_job(job_id)
                 logger.debug(f'cluster done for chunk {chunk} (Cluster job {job_id}).')
 
-                log_files = glob.glob(f"./{job_id}_*")
-                log_files_abs = [os.path.abspath(p) for p in log_files]
+                log_files = Path("./").glob(f"{job_id}_*")
+                log_files_abs = [p.absolute() for p in log_files]
                 logger.debug(f"moving {len(log_files_abs)} log files to {self.cluster_log_dir}")
                 for f in log_files_abs:
                     shutil.move(f, self.cluster_log_dir)
@@ -708,9 +711,9 @@ class WISEDataDESYCluster(WiseDataByVisit):
         """
         Clears the directory where cluster logs are stored
         """
-        fns = os.listdir(self.cluster_log_dir)
+        fns = self.cluster_log_dir.glob()
         for fn in fns:
-            os.remove(os.path.join(self.cluster_log_dir, fn))
+            (self.cluster_log_dir / fn).unlink()
 
     def make_executable_file(self):
         """
@@ -729,8 +732,8 @@ class WISEDataDESYCluster(WiseDataByVisit):
             f'--mask_by_position $2'
         )
 
-        logger.debug("writing executable to " + self.executable_filename)
-        with open(self.executable_filename, "w") as f:
+        logger.debug("writing executable to " + str(self.executable_filename))
+        with self.executable_filename.open("w") as f:
             f.write(txt)
 
     def get_submit_file_filename(self, ids):
@@ -744,7 +747,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
         """
         ids = np.atleast_1d(ids)
         ids_string = f"{min(ids)}-{max(ids)}"
-        return os.path.join(self.cluster_dir, f"ids{ids_string}.submit")
+        return self.cluster_dir / f"ids{ids_string}.submit"
 
     def make_submit_file(
             self,
@@ -764,6 +767,9 @@ class WISEDataDESYCluster(WiseDataByVisit):
         """
 
         q = "1 job_id in " + ", ".join(np.atleast_1d(job_ids).astype(str))
+        d = get_directories()
+        data_dir = str(d['data_dir'])
+        bigdata_dir = str(d['bigdata_dir'])
 
         text = (
             f"executable = {self.executable_filename} \n"
@@ -939,7 +945,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
         _lc = lc if plot_binned else None
 
         if not fn:
-            fn = os.path.join(self.plots_dir, f"{parent_sample_idx}_{lum_key}.pdf")
+            fn = self.plots_dir / f"{parent_sample_idx}_{lum_key}.pdf"
 
         return self._plot_lc(lightcurve=_lc, unbinned_lc=unbinned_lc, interactive=interactive, fn=fn, ax=ax,
                              save=save, lum_key=lum_key, **kwargs)
@@ -1173,10 +1179,8 @@ class WISEDataDESYCluster(WiseDataByVisit):
                 chunk_str = "chunks_" + "_".join([str(c) for c in chunks]) \
                     if len(chunks) != self.n_chunks \
                     else "all_chunks"
-                fn = os.path.join(self.plots_dir, f"chi2_plots", lum_key, f"{n}_datapoints_{kind}_{chunk_str}.pdf")
-                d = os.path.dirname(fn)
-                if not os.path.isdir(d):
-                    os.makedirs(d)
+                fn = self.plots_dir / f"chi2_plots" / lum_key / f"{n}_datapoints_{kind}_{chunk_str}.pdf"
+                fn.parent.mkdir(parents=True, exist_ok=True)
                 logger.debug(f"saving under {fn}")
                 fig.savefig(fn)
 
@@ -1337,10 +1341,8 @@ class WISEDataDESYCluster(WiseDataByVisit):
             chunk_str = "chunks_" + "_".join([str(c) for c in chunks]) \
                 if len(chunks) != self.n_chunks \
                 else "all_chunks"
-            fn = os.path.join(self.plots_dir, f"coverage_plots", lum_key, f"{chunk_str}.pdf")
-            d = os.path.dirname(fn)
-            if not os.path.isdir(d):
-                os.makedirs(d)
+            fn = self.plots_dir / f"coverage_plots" / lum_key / f"{chunk_str}.pdf"
+            fn.parent.mkdir(parents=True, exist_ok=True)
             logger.debug(f"saving under {fn}")
             fig.savefig(fn)
 

--- a/timewise/wise_bigdata_desy_cluster.py
+++ b/timewise/wise_bigdata_desy_cluster.py
@@ -127,7 +127,7 @@ class WISEDataDESYCluster(WiseDataByVisit):
 
         if use_bigdata_dir:
             d = get_directories()
-            fn = fn.replace(d["data_dir"], d["bigdata_dir"])
+            fn = str(fn).replace(str(d["data_dir"]), str(d["bigdata_dir"]))
 
         return Path(str(fn) + ".gz")
 

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -1031,7 +1031,12 @@ class WISEDataBase(abc.ABC):
         logger.debug(f"loading TAP jobs from {tap_jobs_fn}")
         if tap_jobs_fn.is_file():
             with tap_jobs_fn.open("r") as f:
-                self.tap_jobs = json.load(f)
+                tap_jobs_json = json.load(f)
+            # JSON keys are always strings while we need the chunk numbers
+            # to be integers in the dictionary
+            self.tap_jobs = {
+                t: {int(i): url for i, url in v.items()} for t, v in tap_jobs_json.items()
+            }
             logger.debug(f"removing {tap_jobs_fn}")
             tap_jobs_fn.unlink()
         else:

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -221,8 +221,7 @@ class WISEDataBase(abc.ABC):
                  base_name: str,
                  parent_sample_class,
                  min_sep_arcsec,
-                 n_chunks,
-                 tap_url_cache_name=None):
+                 n_chunks):
         """
         Base class for WISE Data
 
@@ -269,7 +268,7 @@ class WISEDataBase(abc.ABC):
         self.output_dir = directories["output_dir"] / base_name
         self.lightcurve_dir = self.output_dir / "lightcurves"
         self.plots_dir = directories["plots_dir"] / base_name
-        self.tap_jobs_cache_dir = self.cache_dir / tap_url_cache_name
+        self.tap_jobs_cache_dir = self.cache_dir / 'tap_cache'
 
         for d in [self.cache_dir, self._cache_photometry_dir, self.cluster_dir, self.cluster_log_dir,
                   self.output_dir, self.lightcurve_dir, self.plots_dir]:
@@ -1000,10 +999,12 @@ class WISEDataBase(abc.ABC):
 
         tap_jobs_fn, queue_fn = self.tap_cache_filenames
         logger.debug(f"saving TAP jobs to {tap_jobs_fn}")
+        tap_jobs_fn.parent.mkdir(parents=True, exist_ok=True)
         with tap_jobs_fn.open("w") as f:
             json.dump(self.tap_jobs, f, indent=4)
         tap_jobs_fn.unlink()
 
+        queue_fn.parent.mkdir(parents=True, exist_ok=True)
         logger.debug(f"saving queue to {queue_fn}")
         with queue_fn.open("w") as f:
             json.dump(list(self.queue.queue), f, indent=4)

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -672,6 +672,8 @@ class WISEDataBase(abc.ABC):
         :type skip_download: bool
         :param mask_by_position: if `True` mask single exposures that are too far away from the bulk
         :type mask_by_position: bool
+        :return: The status of the processing
+        :rtype: bool
         """
 
         mag = True
@@ -1000,8 +1002,8 @@ class WISEDataBase(abc.ABC):
     @property
     def tap_cache_filenames(self):
         return (
-            self.tap_jobs_cache_dir / f"tap_jobs_{self.base_name}.json",
-            self.tap_jobs_cache_dir / f"queue_{self.base_name}.json"
+            self.tap_jobs_cache_dir / f"tap_jobs.json",
+            self.tap_jobs_cache_dir / f"queue.json"
         )
 
     def dump_tap_cache(self):

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -1014,13 +1014,11 @@ class WISEDataBase(abc.ABC):
         tap_jobs_fn.parent.mkdir(parents=True, exist_ok=True)
         with tap_jobs_fn.open("w") as f:
             json.dump(self.tap_jobs, f, indent=4)
-        tap_jobs_fn.unlink()
 
         queue_fn.parent.mkdir(parents=True, exist_ok=True)
         logger.debug(f"saving queue to {queue_fn}")
         with queue_fn.open("w") as f:
             json.dump(list(self.queue.queue), f, indent=4)
-        queue_fn.unlink()
 
     def load_tap_cache(self):
         tap_jobs_fn, queue_fn = self.tap_cache_filenames
@@ -1029,6 +1027,8 @@ class WISEDataBase(abc.ABC):
         if tap_jobs_fn.is_file():
             with tap_jobs_fn.open("r") as f:
                 self.tap_jobs = json.load(f)
+            logger.debug(f"removing {tap_jobs_fn}")
+            tap_jobs_fn.unlink()
         else:
             logger.warning(f"No file {tap_jobs_fn}")
             self.tap_jobs = None
@@ -1041,6 +1041,8 @@ class WISEDataBase(abc.ABC):
                 self.queue = queue.Queue()
                 for q in ql:
                     self.queue.put(q)
+                logger.debug(f"removing {queue_fn}")
+                queue_fn.unlink()
         else:
             logger.warning(f"No file {queue_fn}")
             self.queue = None

--- a/timewise/wise_data_base.py
+++ b/timewise/wise_data_base.py
@@ -652,6 +652,11 @@ class WISEDataBase(abc.ABC):
 
             </path/to/timewise/data/dir>/output/<base_name>/lightcurves/binned_lightcurves_<service>.json
 
+        If service is 'tap' then the process exists on the first call to give the jobs running on the IRSA
+        servers some time. The job infos are cached and loaded on the next function call. `timewise` will
+        then wait on the jobs to finish. If the process is terminated via the keyboard during the waiting
+        the TAP connections will also be cached to be resumed at a later time.
+
         :param remove_chunks: remove single chunk files after binning
         :type remove_chunks: bools
         :param overwrite: overwrite already existing lightcurves and metadata

--- a/timewise/wise_data_by_visit.py
+++ b/timewise/wise_data_by_visit.py
@@ -662,7 +662,7 @@ class WiseDataByVisit(WISEDataBase):
 
         if save:
             if fn is None:
-                fn = os.path.join(self.plots_dir, f"{ind}_binning_diag_{which}cutout.pdf")
+                fn = self.plots_dir / f"{ind}_binning_diag_{which}cutout.pdf"
             logger.debug(f"saving under {fn}")
             fig.savefig(fn)
 


### PR DESCRIPTION
## This will break scripts using earlier `timewise` versions!


When submitting job to the IRSA TAP servers, `timewise` had to stay alive because the job URLs were only stored in memory. This PR introduces the methods `load_tap_cache()` and `dump_tap_cache()` to the `WISEDataBase`. The URLs and the queue are dumped after submission. **The `get_photometric_data` method also exits at this point and has to be called a second time** to resume the job query. If `KeyboardInterrupt` is sent during waiting on the jobs to finish, the cache is also dumped.
For this to work, the **`tap_jobs` attribute is no longer a `dict[str, dict[int, vo.dal.AsyncTAPJob]]` but rather only contains the URL string (`dict[str, dict[int, str]]`)**.

Further, `os.path` is deprecated in favor of `pathlib.Path`. 