### PR TITLE
bug fix so that columns get renamed

### DIFF
--- a/ampel/timewise/alert/TimewiseAlertSupplier.py
+++ b/ampel/timewise/alert/TimewiseAlertSupplier.py
@@ -61,8 +61,8 @@ class TimewiseAlertSupplier(BaseAlertSupplier, AmpelABC):
         if len(columns_to_rename):
             rename = {
                 c: c.replace("_ep", "")
-                for c in columns_to_rename
-                if c.replace("_ep", "") not in table.columns
+                for c in table.columns
+                if (c.replace("_ep", "") not in table.columns) and (c.endswith("_ep"))
             }
             if rename:
                 # in this case only the allwise column eith the _ep extension exists


### PR DESCRIPTION
makes it so if there's no neowise data/only all wise data, the code will still run, by changing column names to have _ep at the end because that's how allwise columns are labeled.